### PR TITLE
Allow optional statusCode in CSV

### DIFF
--- a/bin/akamai-erbulk.py
+++ b/bin/akamai-erbulk.py
@@ -151,8 +151,9 @@ class BulkRedirectManager:
                                 row[1] = "https:" + row[1]
                             if not row[1].startswith("/"):
                                 r["useRelativeUrl"] = "none"
-                            if len(row) == 3 and row[2] == "301" or row[2] == "302":
-                                r["statusCode"] = int(row[2])
+                            if len(row) == 3:
+                                if row[2] == "301" or row[2] == "302":
+                                    r["statusCode"] = int(row[2])
                             count += 1
                             mr.append(r)
                         else:

--- a/bin/akamai-erbulk.py
+++ b/bin/akamai-erbulk.py
@@ -151,6 +151,8 @@ class BulkRedirectManager:
                                 row[1] = "https:" + row[1]
                             if not row[1].startswith("/"):
                                 r["useRelativeUrl"] = "none"
+                            if row[2] == "301" or row[2] == "302":
+                                r["statusCode"] = int(row[2])
                             count += 1
                             mr.append(r)
                         else:

--- a/bin/akamai-erbulk.py
+++ b/bin/akamai-erbulk.py
@@ -151,7 +151,7 @@ class BulkRedirectManager:
                                 row[1] = "https:" + row[1]
                             if not row[1].startswith("/"):
                                 r["useRelativeUrl"] = "none"
-                            if row[2] == "301" or row[2] == "302":
+                            if len(row) === 3 and row[2] == "301" or row[2] == "302":
                                 r["statusCode"] = int(row[2])
                             count += 1
                             mr.append(r)

--- a/bin/akamai-erbulk.py
+++ b/bin/akamai-erbulk.py
@@ -151,7 +151,7 @@ class BulkRedirectManager:
                                 row[1] = "https:" + row[1]
                             if not row[1].startswith("/"):
                                 r["useRelativeUrl"] = "none"
-                            if len(row) === 3 and row[2] == "301" or row[2] == "302":
+                            if len(row) == 3 and row[2] == "301" or row[2] == "302":
                                 r["statusCode"] = int(row[2])
                             count += 1
                             mr.append(r)


### PR DESCRIPTION
For a project we needed to be able to add a status code to the redirects CSV as we wanted to use status code 302. I've modified the Python script to check if the 3rd column has either 301 or 302 in it and to use that value.

I figured this might be a nice addition to this repo as well.